### PR TITLE
Make it more clear you need to use the babel plugin for SSR.

### DIFF
--- a/sections/advanced/server-side-rendering.js
+++ b/sections/advanced/server-side-rendering.js
@@ -48,15 +48,17 @@ const ServerSideRendering = () => md`
 
   > \`sheet.getStyleTags()\` and \`sheet.getStyleElement()\` can only be called after your element is rendered. As a result, components from \`sheet.getStyleElement()\` cannot be combined with \`<YourApp />\` into a larger component.
 
+  You'll also need to customize the \`.babelrc\` and use \`babel-plugin-styled-components\`. Refer to the [tooling documentation](https://www.styled-components.com/docs/tooling#serverside-rendering) for more information.
+
   ### Next.js
 
   Basically you need to add a custom \`pages/_document.js\` (if you don't have one). Then
   [copy the logic](https://github.com/zeit/next.js/tree/master/examples/with-styled-components/pages/_document.js)
   for styled-components to inject the server side rendered styles into the \`<head>\`.
 
-  You'll also need to customize the \`.babelrc\` and use \`babel-plugin-styled-components\`.
-
   Refer to [our example](https://github.com/zeit/next.js/tree/master/examples/with-styled-components) in the Next.js repo for an up-to-date usage example.
+
+  When using Next.js you'll also need to customize the \`.babelrc\` and use \`babel-plugin-styled-components\`. Refer to the [tooling documentation](https://www.styled-components.com/docs/tooling#serverside-rendering) for more information.
 
   ### Streaming Rendering
 


### PR DESCRIPTION
Right now the documentation is a little bit confusing on the fact that you need to use the babel plugin for server side rendering as this is only mentioned in the Next.js section and the tooling itself. I'm not sure if you want to explicitly mention it again in the Next.js but I left it there for now (and slightly updated the text).